### PR TITLE
Update version numbers and fix component attributes

### DIFF
--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,9 +15,9 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>9.0.0</Version>
+	  <Version>9.0.1</Version>
 	  <PackageReleaseNotes>
-      Update to .Net 9
+      Title of code was erroneously set to 'Paragraph' instead of 'Code'
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor
+++ b/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor
@@ -2,7 +2,7 @@
 @using OptionA.Blazor.Components
 @if (Content is not null)
 {
-    <OptABlogComponent Name="**Paragraph**"
+    <OptABlogComponent Name="**Code**"
                        ContentChanged="ContentChanged"
                        ContentRemoved="ContentRemoved"
                        ContentIndex="ContentIndex"

--- a/OptionA.Blazor.Components/OptionA.Blazor.Components.csproj
+++ b/OptionA.Blazor.Components/OptionA.Blazor.Components.csproj
@@ -7,14 +7,14 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<Version>9.0.0</Version>
+		<Version>9.0.1</Version>
 		<IsPackable>true</IsPackable>
 		<Authors>Erik van der Boom</Authors>
 		<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Description>Blazor component library with various component for use inside your Blazor application</Description>
 		<PackageReleaseNotes>
-      Update to .Net 9
+      Added min-width/height for splitter to compensate for changing size
     </PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/OptionA.Blazor.Components/Splitter/OptASplitter.razor.css
+++ b/OptionA.Blazor.Components/Splitter/OptASplitter.razor.css
@@ -25,12 +25,14 @@
 }
 
 [opta-splitter-first] {
-    width: var(--opta-first-width);   
+    width: var(--opta-first-width);
+    min-width: var(--opta-first-width);
 }
 
 [vertical] [opta-splitter-first] {
     height: var(--opta-first-width);
     width: unset;
+    min-width: var(--opta-first-width);
 }
 
 [opta-drag-area] {


### PR DESCRIPTION
Updated version numbers in `OptionA.Blazor.Blog.Builder.csproj` and `OptionA.Blazor.Components.csproj` from `9.0.0` to `9.0.1`. Corrected `PackageReleaseNotes` in both projects. Fixed `Name` attribute in `OptACodeBuilder.razor` from "Paragraph" to "Code". Added `min-width` properties in `OptASplitter.razor.css` to ensure minimum width for splitters.