### PR TITLE
Add OptAHelperList component and update attribute handling

### DIFF
--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
@@ -44,6 +44,11 @@
                                 ItemTitle="Default classes to remove"
                                 Label="Removed default classes"
                                 Items="Content.RemovedClasses" />
+                <OptAHelperList ContentChanged="ContentChanged"
+                                ItemPlaceholder="attribute=value.."
+                                ItemTitle="Additional attributes to set"
+                                Label="Additional attributes"
+                                Items="_additionalAttributes" />
                 @if (AdditionalProperties is not null)
                 {
                     @AdditionalProperties

--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
@@ -72,10 +72,25 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
         [Inject]
         private IJSRuntime JsRuntime { get; set; } = null!;
 
+        private List<string>? _additionalAttributes;
+
         private bool _showDialog;
         private bool _awaitShow, _awaitClose;
         private ElementReference _dialog;
         private IJSObjectReference? _module;
+
+        /// <inheritdoc/>
+        protected override void OnParametersSet()
+        {
+            if (Content is not null)
+            {
+                _additionalAttributes = Content.Attributes.Select(x => $"{x.Key}={x.Value}").ToList();
+            }
+            else
+            {
+                _additionalAttributes = null;
+            }
+        }
 
         private void EditProperties()
         {

--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptAHelperList.razor.cs
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptAHelperList.razor.cs
@@ -38,7 +38,7 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
         /// <inheritdoc/>
         protected override void OnParametersSet()
         {
-            if (Items is not null && !Items.Any())
+            if (Items is not null && !Items.Any(string.IsNullOrEmpty))
             {
                 AddItem();                
             }

--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,9 +15,9 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>8.2.0</Version>
+	  <Version>8.2.1</Version>
 	  <PackageReleaseNotes>
-      Added new List component
+      Fixes for additional atributes and update from blog package
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Blog/List/OptAListContent.razor.cs
+++ b/OptionA.Blazor.Blog/List/OptAListContent.razor.cs
@@ -25,7 +25,7 @@ namespace OptionA.Blazor.Blog
 
             _content = Content.Items
                     .Where(item => !string.IsNullOrEmpty(item))
-                    .Select(item => new TextContent { Content = item });
+                    .Select(item => new InlineContent { Content = item });
 
             await InvokeAsync(StateHasChanged);
         }

--- a/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
+++ b/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
@@ -15,9 +15,9 @@
     <Description>Components for viewing a Blog using Blazor, Use the Builder project to build blogs.</Description>
 	<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Version>8.2.0</Version>
+	<Version>8.2.1</Version>
 	<PackageReleaseNotes>
-    Added new List component for displaying a list of items
+    Fixed a bug for rendering the list, added basic markdown support for list items
   </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Blog/Services/BuilderService.cs
+++ b/OptionA.Blazor.Blog/Services/BuilderService.cs
@@ -303,6 +303,16 @@ namespace OptionA.Blazor.Blog.Services
                         ? JsonSerializer.Deserialize<string>(height)
                         : default,
                 },
+                ContentType.List => new ListContent
+                {
+                    ListType = content.TryGetValue(nameof(ListContent.ListType), out var listType)
+                        ? JsonSerializer.Deserialize<ListType>(listType)
+                        : ListType.UnorderedList,
+                    Items = content.TryGetValue(nameof(ListContent.Items), out var items)
+                        ? JsonSerializer.Deserialize<List<string>>(items) ?? []
+                        : [],
+
+                },
                 _ => throw new NotSupportedException($"Canoot create postcontent for type {type}")
             };
 


### PR DESCRIPTION
- Added `OptAHelperList` to `OptABlogComponent.razor` for additional attributes
- Introduced `_additionalAttributes` field in `OptABlogComponent.razor.cs`
- Implemented `OnParametersSet` to initialize `_additionalAttributes`
- Modified `OptAHelperList.razor.cs` to add only non-empty items
- Updated version in `OptionA.Blazor.Blog.Builder.csproj` to `8.2.1`
- Changed `OptAListContent.razor.cs` to use `InlineContent` for non-empty items
- Updated version in `OptionA.Blazor.Blog.csproj` to `8.2.1`
- Added support for `ContentType.List` in `BuilderService.cs`