### PR TITLE
Fix attribute handling in OptABlogComponent

### DIFF
--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
@@ -44,7 +44,7 @@
                                 ItemTitle="Default classes to remove"
                                 Label="Removed default classes"
                                 Items="Content.RemovedClasses" />
-                <OptAHelperList ContentChanged="ContentChanged"
+                <OptAHelperList ContentChanged="AttributesChanged"
                                 ItemPlaceholder="attribute=value.."
                                 ItemTitle="Additional attributes to set"
                                 Label="Additional attributes"

--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
@@ -84,7 +84,7 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
         {
             if (Content is not null)
             {
-                _additionalAttributes = Content.Attributes.Select(x => $"{x.Key}={x.Value}").ToList();
+                _additionalAttributes ??= Content.Attributes.Select(x => $"{x.Key}={x.Value}").ToList();
             }
             else
             {
@@ -141,6 +141,27 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
                 await _module.InvokeVoidAsync(CloseDialogFunction, _dialog);
                 OnDialogClose();
             }
+        }
+
+        private async Task AttributesChanged()
+        {
+            if (_additionalAttributes is null || Content is null)
+            {
+                return;
+            }
+
+            Content.Attributes.Clear();
+            foreach (var attr in _additionalAttributes)
+            {
+                var split = attr.Split('=');
+                if (split.Length != 2)
+                {
+                    continue;
+                }
+                Content.Attributes.Add(split[0], split[1]);
+            }
+
+            await ContentChanged.InvokeAsync();
         }
 
         private Dictionary<string, object?> GetMoveUpAttributes()

--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,9 +15,9 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>9.1.1</Version>
+	  <Version>9.1.2</Version>
 	  <PackageReleaseNotes>
-      Update of blob package
+      Fix for list helper for attributes
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
Updated OptABlogComponent.razor to use AttributesChanged event handler for OptAHelperList. Initialized _additionalAttributes list only if null in OptABlogComponent.razor.cs. Added private method AttributesChanged to update Content.Attributes and invoke ContentChanged event. Incremented version to 9.1.2 in OptionA.Blazor.Blog.Builder.csproj and updated release notes.