### PR TITLE
Update event handler and attributes handling

### DIFF
--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor
@@ -44,7 +44,7 @@
                                 ItemTitle="Default classes to remove"
                                 Label="Removed default classes"
                                 Items="Content.RemovedClasses" />
-                <OptAHelperList ContentChanged="ContentChanged"
+                <OptAHelperList ContentChanged="AttributesChanged"
                                 ItemPlaceholder="attribute=value.."
                                 ItemTitle="Additional attributes to set"
                                 Label="Additional attributes"

--- a/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
+++ b/OptionA.Blazor.Blog.Builder/HelperComponents/OptABlogComponent.razor.cs
@@ -84,7 +84,7 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
         {
             if (Content is not null)
             {
-                _additionalAttributes = Content.Attributes.Select(x => $"{x.Key}={x.Value}").ToList();
+                _additionalAttributes ??= Content.Attributes.Select(x => $"{x.Key}={x.Value}").ToList();
             }
             else
             {
@@ -141,6 +141,27 @@ namespace OptionA.Blazor.Blog.Builder.HelperComponents
                 await _module.InvokeVoidAsync(CloseDialogFunction, _dialog);
                 OnDialogClose();
             }
+        }
+
+        private async Task AttributesChanged()
+        {
+            if (_additionalAttributes is null || Content is null)
+            {
+                return;
+            }
+
+            Content.Attributes.Clear();
+            foreach (var attr in _additionalAttributes)
+            {
+                var split = attr.Split('=');
+                if (split.Length != 2)
+                {
+                    continue;
+                }
+                Content.Attributes.Add(split[0], split[1]);
+            }
+
+            await ContentChanged.InvokeAsync();
         }
 
         private Dictionary<string, object?> GetMoveUpAttributes()

--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,7 +15,7 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>8.2.1</Version>
+	  <Version>8.2.2</Version>
 	  <PackageReleaseNotes>
       Fixes for additional atributes and update from blog package
     </PackageReleaseNotes>


### PR DESCRIPTION
- Changed event handler in `OptABlogComponent.razor` from `ContentChanged` to `AttributesChanged` for `OptAHelperList`.
- Modified `OnParametersSet` in `OptABlogComponent.razor.cs` to use null-coalescing assignment for `_additionalAttributes`.
- Added `AttributesChanged` method in `OptABlogComponent.razor.cs` to update `Content.Attributes` and invoke `ContentChanged`.
- Incremented version in `OptionA.Blazor.Blog.Builder.csproj` from `8.2.1` to `8.2.2` with release notes for attribute fixes and blog package update.