### PR TITLE
Add support for custom code languages and refactorings

### DIFF
--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,9 +15,9 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>8.2.2</Version>
+	  <Version>8.2.3</Version>
 	  <PackageReleaseNotes>
-      Fixes for additional atributes and update from blog package
+      Added other option to code builder
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor
+++ b/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor
@@ -14,6 +14,17 @@
             <OptAChild Content="@DataProvider.GetContent(BuilderType.Label, "Language")" />
         </label>
         <OptAEnumSelect TEnum="CodeLanguage" @bind-Value="InternalLanguage" Attributes="@GetCodeLanguageAttributes()" />
+        @if (InternalLanguage == CodeLanguage.Other)
+        {
+            <label @attributes="@GetLabelAttributes(OtherLanguageId)">
+                <OptAChild Content="@DataProvider.GetContent(BuilderType.Label, "Other")" />
+            </label>
+            <OptAInputText @bind-Value="Content.OtherLanguage" Attributes="@GetOtherLanguageAttributes()" />
+        }
+        <label @attributes="@GetLabelAttributes(OtherLanguageId)">
+            <OptAChild Content="@DataProvider.GetContent(BuilderType.Label, "Other")" />
+        </label>
+        <OptAInputText @bind-Value="Content.OtherLanguage" Attributes="@GetOtherLanguageAttributes()" />
         <label @attributes="@GetLabelAttributes(CodeId)">
             <OptAChild Content="@DataProvider.GetContent(BuilderType.Label, "Code")" />
         </label>

--- a/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor.cs
+++ b/OptionA.Blazor.Blog.Builder/Parts/OptACodeBuilder.razor.cs
@@ -9,6 +9,7 @@ namespace OptionA.Blazor.Blog.Builder.Parts
     {
         private const string CodeId = "opta-code";
         private const string CodeLanguageId = "opta-code-Language";
+        private const string OtherLanguageId = "opta-other-Language";
 
         /// <summary>
         /// Index of the current content in the collection
@@ -87,6 +88,16 @@ namespace OptionA.Blazor.Blog.Builder.Parts
             };
 
             return DataProvider.GetAttributes(BuilderType.SelectInput, defaultAttributes);
+        }
+
+        private Dictionary<string, object?> GetOtherLanguageAttributes()
+        {
+            var defaultAttributes = new Dictionary<string, object?>
+            {
+                ["id"] = $"{OtherLanguageId}-{ContentIndex}"
+            };
+
+            return DataProvider.GetAttributes(BuilderType.TextInput, defaultAttributes);
         }
 
 

--- a/OptionA.Blazor.Blog/Code/CodeContent.cs
+++ b/OptionA.Blazor.Blog/Code/CodeContent.cs
@@ -15,6 +15,10 @@
         /// Language of the code
         /// </summary>
         public CodeLanguage Language { get; set; }
+        /// <summary>
+        /// If Language is Other, this is the language to display
+        /// </summary>
+        public string? OtherLanguage { get; set; }
         /// <inheritdoc/>
         public override bool IsInvalid => string.IsNullOrEmpty(Code);
     }

--- a/OptionA.Blazor.Blog/Code/CodeLanguage.cs
+++ b/OptionA.Blazor.Blog/Code/CodeLanguage.cs
@@ -49,6 +49,14 @@ namespace OptionA.Blazor.Blog
         /// </summary>
         CPlusPlus,
         /// <summary>
+        /// PowerShell
+        /// </summary>
+        PowerShell,
+        /// <summary>
+        /// Bash
+        /// </summary>
+        Bash,
+        /// <summary>
         /// Something else
         /// </summary>
         Other

--- a/OptionA.Blazor.Blog/Code/OptACode.razor.cs
+++ b/OptionA.Blazor.Blog/Code/OptACode.razor.cs
@@ -24,9 +24,12 @@ namespace OptionA.Blazor.Blog
                 {
                     return null;
                 }
+                var language = Content.Language == CodeLanguage.Other && !string.IsNullOrEmpty(Content.OtherLanguage) 
+                    ? Content.OtherLanguage 
+                    : Content.Language.ToDisplayLanguage();
                 var result = new BlockContent
                 {
-                    Content = Content.Language.ToDisplayLanguage()
+                    Content = language
                 };
                 result.Attributes["opta-code"] = "header";
                 return result;

--- a/OptionA.Blazor.Blog/Code/Parsers/CSharpParser.cs
+++ b/OptionA.Blazor.Blog/Code/Parsers/CSharpParser.cs
@@ -145,8 +145,8 @@
             "with",
         ];
         /// <inheritdoc/>
-        protected override char[] Specials => new[]
-        {
+        protected override char[] Specials =>
+        [
             '(',
             '<',
             '.',
@@ -162,7 +162,7 @@
             '|',
             '[',
             ']'
-        };
+        ];
 
         /// <inheritdoc/>
         protected override Dictionary<string, WordTypeModel> StringStarters => new()

--- a/OptionA.Blazor.Blog/Core/Extensions/ContentExtensions.cs
+++ b/OptionA.Blazor.Blog/Core/Extensions/ContentExtensions.cs
@@ -49,6 +49,7 @@ namespace OptionA.Blazor.Blog
             {
                 CodeLanguage.CSharp => "C#",
                 CodeLanguage.Html => "HTML",
+                CodeLanguage.CPlusPlus => "C++",
                 _ => $"{language}"
             };
         }

--- a/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
+++ b/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
@@ -15,9 +15,9 @@
     <Description>Components for viewing a Blog using Blazor, Use the Builder project to build blogs.</Description>
 	<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Version>8.2.1</Version>
+	<Version>8.2.2</Version>
 	<PackageReleaseNotes>
-    Fixed a bug for rendering the list, added basic markdown support for list items
+    Added support for custom code language in code blocks.
   </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
Updated OptionA.Blazor.Blog.Builder to version 8.2.3 and OptionA.Blazor.Blog to version 8.2.2. Added handling for "Other" language in OptACodeBuilder.razor, including new label and input field. Introduced OtherLanguageId constant and GetOtherLanguageAttributes method in OptACodeBuilder.razor.cs. Updated CodeContent class with OtherLanguage property. Added PowerShell and Bash to CodeLanguage enum. Enhanced OptACode.razor.cs to display "Other" language. Refactored CSharpParser.cs for Specials array syntax. Updated ContentExtensions.cs to include display name for CPlusPlus language.