### PR TITLE
Rename service methods and add ServiceLifetime parameter

### DIFF
--- a/OptionA.Blazor.Blog.Builder/ServiceCollectionExtensions.cs
+++ b/OptionA.Blazor.Blog.Builder/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOptionABlogBuilder(this IServiceCollection services, Action<OptABlogBuilderOptions>? configuration = null)
     {
         services
-            .AddStorageService();
+            .AddOptionAStorageService();
         services
             .TryAddSingleton<IBuilderService, BuilderService>();
         services

--- a/OptionA.Blazor.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/OptionA.Blazor.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -13,28 +13,57 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Adds the following services to the container:
-    /// <para><see cref="ServiceLifetime.Scoped"/> <see cref="IStorageService"/> for storing and retrieving from local and or session storage</para>
+    /// <para><see cref="IStorageService"/> with given <see cref="ServiceLifetime" /> for storing and retrieving from local and or session storage</para>
     /// </summary>
     /// <param name="services"></param>
+    /// <param name="serviceLifetime"></param>
     /// <returns></returns>
-    public static IServiceCollection AddStorageService(this IServiceCollection services)
+    public static IServiceCollection AddOptionAStorageService(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
     {
-        services
-            .TryAddScoped<IStorageService, StorageService>();
+        switch (serviceLifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services
+                    .TryAddSingleton<IStorageService, StorageService>();
+                break;
+            case ServiceLifetime.Transient:
+                services
+                    .TryAddTransient<IStorageService, StorageService>();
+                break;
+            case ServiceLifetime.Scoped:
+                services
+                    .TryAddScoped<IStorageService, StorageService>();
+                break;
+        }
 
         return services;
     }
 
     /// <summary>
     /// Adds the following services to the container:        
-    /// <para><see cref="ServiceLifetime.Scoped"/> <see cref="IDatabaseService"/> for storing and retrieving from indexed db</para>
+    /// <para> <see cref="IDatabaseService"/> with given <see cref="ServiceLifetime" /> for storing and retrieving from indexed db</para>
     /// </summary>
     /// <param name="services"></param>
     /// <returns></returns>
-    public static IServiceCollection AddDatabaseService(this IServiceCollection services)
+    public static IServiceCollection AddOptionADatabaseService(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
     {
+        switch (serviceLifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services
+                    .TryAddSingleton<IDatabaseService, DatabaseService>();
+                break;
+            case
+            ServiceLifetime.Transient:
+                services
+                    .TryAddTransient<IDatabaseService, DatabaseService>();
+                break;
+            case ServiceLifetime.Scoped:
+                services
+                    .TryAddScoped<IDatabaseService, DatabaseService>();
+            break;
+        }
         services
-            .AddScoped<IDatabaseService, DatabaseService>()
             .TryAddSingleton<MigrationBuilder>();
 
         return services;
@@ -42,18 +71,33 @@ public static class ServiceCollectionExtensions
 
     /// <summary>
     /// Adds the following services to the container:
-    /// <para><see cref="ServiceLifetime.Scoped"/> <see cref="IFileSystem"/> for file system access using the browser</para>
-    /// <para><see cref="ServiceLifetime.Scoped"/> <see cref="IDatabaseService"/> for storing filehandles</para>
-    /// <para><see cref="ServiceLifetime.Scoped"/> <see cref="IStorageService"/> for session id</para>
+    /// <para><see cref="IFileSystem"/> with given <see cref="ServiceLifetime" /> for file system access using the browser</para>
+    /// <para><see cref="IDatabaseService"/> with given <see cref="ServiceLifetime" /> for storing filehandles</para>
+    /// <para><see cref="IStorageService"/> with given <see cref="ServiceLifetime" /> for session id</para>
     /// </summary>
     /// <param name="services"></param>
     /// <returns></returns>
-    public static IServiceCollection AddStorageServices(this IServiceCollection services)
+    public static IServiceCollection AddOptionAStorageServices(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
     {
+        switch (serviceLifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services
+                    .TryAddSingleton<IFileSystem, FileSystem>();
+                break;
+            case ServiceLifetime.Transient:
+                services
+                    .TryAddTransient<IFileSystem, FileSystem>();
+                break;
+            case ServiceLifetime.Scoped:
+                services
+                    .TryAddScoped<IFileSystem, FileSystem>();
+                break;
+        }
+
         return services
-            .AddDatabaseService()
-            .AddStorageService()
-            .AddScoped<IFileSystem, FileSystem>()
-            .RegisterMigration<M001_FileSystem_Initialize>();
+            .AddOptionADatabaseService(serviceLifetime)
+            .AddOptionAStorageService(serviceLifetime)
+            .RegisterMigration<M001_FileSystem_Initialize>();           
     }
 }

--- a/OptionA.Blazor.Storage/OptionA.Blazor.Storage.csproj
+++ b/OptionA.Blazor.Storage/OptionA.Blazor.Storage.csproj
@@ -7,14 +7,14 @@
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
-  	<Version>9.1.0</Version>
+  	<Version>9.1.1</Version>
 	<IsPackable>true</IsPackable>
 	<Authors>Erik van der Boom</Authors>
 	<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<Description>Blazor class library with services to access local storage, session storage and indexed db</Description>
     <PackageReleaseNotes>
-      Added File System Storage for Blazor
+      Made service collection extensions have optional servicelifetime parameter
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Test/Program.cs
+++ b/OptionA.Blazor.Test/Program.cs
@@ -55,7 +55,7 @@ builder.Services
             componentBar.Class += " top-60";
         }
     })
-    .AddStorageServices();
+    .AddOptionAStorageServices();
 await builder.Build().RunAsync();
 
 static BuilderTypeProperties IconButton(string icon)


### PR DESCRIPTION
Updated ServiceCollectionExtensions to rename methods and add ServiceLifetime parameter. Methods now use switch statements to handle different lifetimes. Incremented version in OptionA.Blazor.Storage.csproj to 9.1.1. Updated Program.cs to reflect method name changes.