### PR TITLE
Bump versions and update enum select behavior

### DIFF
--- a/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
+++ b/OptionA.Blazor.Blog.Builder/OptionA.Blazor.Blog.Builder.csproj
@@ -15,9 +15,9 @@
 	  <Description>Builder for creating a Blog using Blazor.</Description>
 	  <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>9.4.1</Version>
+	  <Version>9.4.2</Version>
 	  <PackageReleaseNotes>
-      Made enum radiogroup and enum select nullable to have no initial value
+      Remove none option after selecting a value in enum select
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Components.Direct/Input/OptAEnumSelect.razor
+++ b/OptionA.Blazor.Components.Direct/Input/OptAEnumSelect.razor
@@ -7,7 +7,7 @@
 @if (_values is not null)
 {
     <InputSelect @bind-Value="InternalValue" AdditionalAttributes="GetAllAttributes()" @ref="_select">
-        @if (ShowNoneOption ?? false)
+        @if ((ShowNoneOption ?? false) && !InternalValue.HasValue)
         {
             <option @attributes="@GetOptionAttributes(null)">@GetDisplayName(null)</option>
         }

--- a/OptionA.Blazor.Components.Direct/Input/OptAEnumSelect.razor.cs
+++ b/OptionA.Blazor.Components.Direct/Input/OptAEnumSelect.razor.cs
@@ -150,7 +150,7 @@ public partial class OptAEnumSelect<TEnum> where TEnum : struct, Enum
         }
         else if (!value.HasValue)
         {
-            return NoneOptionName ?? "None";
+            return NoneOptionName ?? "None...";
         }
         
         return $"{value}";

--- a/OptionA.Blazor.Components.Direct/OptionA.Blazor.Components.Direct.csproj
+++ b/OptionA.Blazor.Components.Direct/OptionA.Blazor.Components.Direct.csproj
@@ -7,14 +7,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
-    <Version>9.2.1</Version>
+    <Version>9.2.2</Version>
     <IsPackable>true</IsPackable>
     <Authors>Erik van der Boom</Authors>
     <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>Blazor component library with various component for use inside your Blazor application, direct components do not require setup</Description>
     <PackageReleaseNotes>
-      Made enum radiogroup and enum select nullable to have no initial value
+      Remove none option after selecting a value in enum select
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/OptionA.Blazor.Components/OptionA.Blazor.Components.csproj
+++ b/OptionA.Blazor.Components/OptionA.Blazor.Components.csproj
@@ -7,14 +7,14 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<Version>9.3.1</Version>
+		<Version>9.3.2</Version>
 		<IsPackable>true</IsPackable>
 		<Authors>Erik van der Boom</Authors>
 		<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Description>Blazor component library with various component for use inside your Blazor application</Description>
 		<PackageReleaseNotes>
-      Made enum radiogroup and enum select nullable to have no initial value
+      Remove none option after selecting a value in enum select
     </PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
- Increment version numbers for OptionA.Blazor.Blog (9.4.1 to 9.4.2), OptionA.Blazor.Components.Direct (9.2.1 to 9.2.2), and OptionA.Blazor.Components (9.3.1 to 9.3.2).

- Modify OptAEnumSelect.razor to display the "none" option only when ShowNoneOption is true and InternalValue is null.

- Change return value in OptAEnumSelect.razor.cs from "None" to "None..." when no value is present.

- Update release notes to reflect the removal of the "none" option after selecting a value in the enum select component.