### PR TITLE
Add non-modal mode to OptAModal component

### DIFF
--- a/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
+++ b/OptionA.Blazor.Blog/OptionA.Blazor.Blog.csproj
@@ -1,37 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>OptionA.Blazor.Blog</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<PackageReadmeFile>readme.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
     <Title>Blazor Blog Components</Title>
     <Authors>Erik van der Boom</Authors>
-	<IsPackable>true</IsPackable>
+    <IsPackable>true</IsPackable>
     <Description>Components for viewing a Blog using Blazor, Use the Builder project to build blogs.</Description>
-	<PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Version>9.2.4</Version>
-	<PackageReleaseNotes>
-    Fixed an issue with parsing custom attributes
+    <PackageProjectUrl>https://github.com/evdboom/OptionA.Blazor</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>9.2.5</Version>
+    <PackageReleaseNotes>
+    Allow modal to open in a non modal way
   </PackageReleaseNotes>
   </PropertyGroup>
-
-
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
   </ItemGroup>
-
   <ItemGroup>
-	  <None Include="readme.md" Pack="true" PackagePath="\" />
+    <None Include="readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-
 </Project>

--- a/OptionA.Blazor.Components/Modal/OptAModal.razor.js
+++ b/OptionA.Blazor.Components/Modal/OptAModal.razor.js
@@ -1,9 +1,14 @@
-﻿export const showDialog = (dialogElement, dotNetHelper, closeHandlerName) => {
+﻿export const showDialog = (dialogElement, dotNetHelper, closeHandlerName, isModal) => {
     if (!dialogElement) {
         return;
     }
 
-    dialogElement.showModal();
+    if (isModal) {
+        dialogElement.showModal();
+    } else {
+        dialogElement.show();
+    }
+    
     dialogElement.addEventListener("close", async () => {
         await dotNetHelper.invokeMethodAsync(closeHandlerName);
     });

--- a/OptionA.Blazor.Test/Pages/Modal.razor
+++ b/OptionA.Blazor.Test/Pages/Modal.razor
@@ -16,6 +16,16 @@ else
 <button @onclick="ChangeSize">
     @_size
 </button>
+<button @onclick="ChangeModal">
+    @if (_asModal)
+    {
+        <span>As modal</span>
+    }
+    else
+    {
+        <span>As Dialog</span>
+    }
+</button>
 <button @onclick="() => _modal?.Show()">
     Show
 </button>
@@ -24,7 +34,8 @@ else
 <OptAModal @ref="_modal"
            Draggable="_draggable"
            Size="_size"
-           DragMode="_dragMode">
+           DragMode="_dragMode"
+           IsModal="_asModal">
     <Header>
         <h1>My first modal</h1>
     </Header>

--- a/OptionA.Blazor.Test/Pages/Modal.razor.cs
+++ b/OptionA.Blazor.Test/Pages/Modal.razor.cs
@@ -8,13 +8,20 @@ public partial class Modal
     private bool _draggable;
     private ModalSize _size;
     private DragMode _dragMode;
+    private bool _asModal = true;
 
     private string _text = string.Empty;
+
+    private void ChangeModal()
+    {
+        _asModal = !_asModal;
+    }
 
     private void ChangeDraggable()
     {
         _draggable = !_draggable;
     }
+
     private void ChangeDragMode()
     {
         if (_dragMode == DragMode.Direct)
@@ -26,7 +33,8 @@ public partial class Modal
             _dragMode = DragMode.Direct;
         }
     }
-    private void ChangeSize() 
+
+    private void ChangeSize()
     {
         if (_size == ModalSize.Default)
         {
@@ -45,5 +53,4 @@ public partial class Modal
             _size = ModalSize.Default;
         }
     }
-
 }


### PR DESCRIPTION
Enhanced the `OptAModal` component to support both modal and non-modal modes via a new `IsModal` parameter. Updated the corresponding JavaScript logic to conditionally use `showModal()` or `show()`.

Refactored `OptAModal.razor.cs` for improved readability, added new parameters (`Header`, `Content`, `Footer`, `OnClose`, `OnShow`, `Draggable`, `DragMode`, `Size`), and updated `OnAfterRenderAsync` to pass `IsModal` to JavaScript.

Updated `Modal.razor` and `Modal.razor.cs` to demonstrate the new functionality, including a toggle button for switching between modal and non-modal modes.

Improved formatting and metadata in `OptionA.Blazor.Blog.csproj`, including version bump to `9.2.5` and updated release notes. Simplified dictionary initialization in several methods for better maintainability.